### PR TITLE
Refine: auto fetching images and annotation files instead of specifying.

### DIFF
--- a/config.json
+++ b/config.json
@@ -58,7 +58,6 @@
         "type": "PICKDataset",
         "args": {
             "entities_list": ["company", "address", "date", "total"],
-            "image_ext": ".jpg",
             "files_name":"data/data_examples_root/train_samples_list.csv",
             "boxes_and_transcripts_folder":"boxes_and_transcripts",
             "images_folder":"images",
@@ -72,7 +71,6 @@
         "type": "PICKDataset",
         "args": {
             "entities_list": ["company", "address", "date", "total"],
-            "image_ext": ".jpg",
             "files_name":"data/data_examples_root/train_samples_list.csv",
             "boxes_and_transcripts_folder":"boxes_and_transcripts",
             "images_folder":"images",


### PR DESCRIPTION
Auto parse the extension and fetch the data, assuming the extensions are consistent within a dataset (note `train_dataset` and `val_dataset` are two datasets).

@dbobrenko @wenwenyu Hi, if possible, would you please check if it fits what are required? Thanks.